### PR TITLE
feat: 방 상세 정보 조회 기능 구현

### DIFF
--- a/src/main/java/com/moabam/api/application/MemberService.java
+++ b/src/main/java/com/moabam/api/application/MemberService.java
@@ -2,11 +2,14 @@ package com.moabam.api.application;
 
 import static com.moabam.global.error.model.ErrorMessage.*;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.moabam.api.domain.entity.Member;
 import com.moabam.api.domain.repository.MemberRepository;
+import com.moabam.api.domain.repository.MemberSearchRepository;
 import com.moabam.global.error.exception.NotFoundException;
 
 import lombok.RequiredArgsConstructor;
@@ -17,9 +20,19 @@ import lombok.RequiredArgsConstructor;
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final MemberSearchRepository memberSearchRepository;
 
 	public Member getById(Long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+	}
+
+	public Member getManager(Long roomId) {
+		return memberSearchRepository.findManager(roomId)
+			.orElseThrow(() -> new NotFoundException(MEMBER_NOT_FOUND));
+	}
+
+	public List<Member> getRoomMembers(List<Long> memberIds) {
+		return memberRepository.findAllById(memberIds);
 	}
 }

--- a/src/main/java/com/moabam/api/application/RoomService.java
+++ b/src/main/java/com/moabam/api/application/RoomService.java
@@ -22,6 +22,7 @@ import com.moabam.api.dto.CreateRoomRequest;
 import com.moabam.api.dto.EnterRoomRequest;
 import com.moabam.api.dto.ModifyRoomRequest;
 import com.moabam.api.dto.RoomMapper;
+import com.moabam.api.dto.RoutineMapper;
 import com.moabam.global.error.exception.BadRequestException;
 import com.moabam.global.error.exception.ForbiddenException;
 import com.moabam.global.error.exception.NotFoundException;
@@ -42,7 +43,7 @@ public class RoomService {
 	@Transactional
 	public void createRoom(Long memberId, CreateRoomRequest createRoomRequest) {
 		Room room = RoomMapper.toRoomEntity(createRoomRequest);
-		List<Routine> routines = RoomMapper.toRoutineEntity(room, createRoomRequest.routines());
+		List<Routine> routines = RoutineMapper.toRoutineEntities(room, createRoomRequest.routines());
 		Participant participant = Participant.builder()
 			.room(room)
 			.memberId(memberId)

--- a/src/main/java/com/moabam/api/application/RoomService.java
+++ b/src/main/java/com/moabam/api/application/RoomService.java
@@ -3,26 +3,41 @@ package com.moabam.api.application;
 import static com.moabam.api.domain.entity.enums.RoomType.*;
 import static com.moabam.global.error.model.ErrorMessage.*;
 
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.moabam.api.domain.entity.Certification;
+import com.moabam.api.domain.entity.DailyMemberCertification;
+import com.moabam.api.domain.entity.DailyRoomCertification;
 import com.moabam.api.domain.entity.Member;
 import com.moabam.api.domain.entity.Participant;
 import com.moabam.api.domain.entity.Room;
 import com.moabam.api.domain.entity.Routine;
 import com.moabam.api.domain.entity.enums.RoomType;
+import com.moabam.api.domain.repository.CertificationsMapper;
+import com.moabam.api.domain.repository.CertificationsSearchRepository;
 import com.moabam.api.domain.repository.ParticipantRepository;
 import com.moabam.api.domain.repository.ParticipantSearchRepository;
 import com.moabam.api.domain.repository.RoomRepository;
 import com.moabam.api.domain.repository.RoutineRepository;
+import com.moabam.api.domain.repository.RoutineSearchRepository;
+import com.moabam.api.dto.CertificationImageResponse;
 import com.moabam.api.dto.CreateRoomRequest;
 import com.moabam.api.dto.EnterRoomRequest;
 import com.moabam.api.dto.ModifyRoomRequest;
+import com.moabam.api.dto.RoomDetailsResponse;
 import com.moabam.api.dto.RoomMapper;
 import com.moabam.api.dto.RoutineMapper;
+import com.moabam.api.dto.RoutineResponse;
+import com.moabam.api.dto.TodayCertificateRankResponse;
 import com.moabam.global.error.exception.BadRequestException;
 import com.moabam.global.error.exception.ForbiddenException;
 import com.moabam.global.error.exception.NotFoundException;
@@ -36,8 +51,10 @@ public class RoomService {
 
 	private final RoomRepository roomRepository;
 	private final RoutineRepository routineRepository;
+	private final RoutineSearchRepository routineSearchRepository;
 	private final ParticipantRepository participantRepository;
 	private final ParticipantSearchRepository participantSearchRepository;
+	private final CertificationsSearchRepository certificationsSearchRepository;
 	private final MemberService memberService;
 
 	@Transactional
@@ -108,6 +125,24 @@ public class RoomService {
 		roomRepository.delete(room);
 	}
 
+	public RoomDetailsResponse getRoomDetails(Long memberId, Long roomId) {
+		LocalDate today = LocalDate.now();
+		Participant participant = getParticipant(memberId, roomId);
+		Room room = participant.getRoom();
+
+		String managerNickname = getRoomManagerNickname(roomId);
+		List<DailyMemberCertification> dailyMemberCertifications = getDailyMemberCertificationSorted(roomId, today);
+		List<RoutineResponse> routineResponses = getRoutineResponses(roomId);
+		List<TodayCertificateRankResponse> todayCertificateRankResponses = getTodayCertificateRankResponses(roomId,
+			routineResponses, dailyMemberCertifications, today);
+		List<LocalDate> certifiedDates = getCertifiedDates(roomId, today);
+		double completePercentage = calculateCompletePercentage(dailyMemberCertifications.size(),
+			room.getCurrentUserCount());
+
+		return RoomMapper.toRoomDetailsResponse(room, managerNickname, routineResponses, certifiedDates,
+			todayCertificateRankResponses, completePercentage);
+	}
+
 	public void validateRoomById(Long roomId) {
 		if (!roomRepository.existsById(roomId)) {
 			throw new NotFoundException(ROOM_NOT_FOUND);
@@ -115,7 +150,7 @@ public class RoomService {
 	}
 
 	private Participant getParticipant(Long memberId, Long roomId) {
-		return participantSearchRepository.findParticipant(memberId, roomId)
+		return participantSearchRepository.findByMemberIdAndRoomId(memberId, roomId)
 			.orElseThrow(() -> new NotFoundException(PARTICIPANT_NOT_FOUND));
 	}
 
@@ -127,11 +162,9 @@ public class RoomService {
 		if (!isEnterRoomAvailable(memberId, room.getRoomType())) {
 			throw new BadRequestException(MEMBER_ROOM_EXCEED);
 		}
-
 		if (!StringUtils.isEmpty(requestPassword) && !room.getPassword().equals(requestPassword)) {
 			throw new BadRequestException(WRONG_ROOM_PASSWORD);
 		}
-
 		if (room.getCurrentUserCount() == room.getMaxUserCount()) {
 			throw new BadRequestException(ROOM_MAX_USER_REACHED);
 		}
@@ -143,7 +176,6 @@ public class RoomService {
 		if (roomType.equals(MORNING) && member.getCurrentMorningCount() >= 3) {
 			return false;
 		}
-
 		if (roomType.equals(NIGHT) && member.getCurrentNightCount() >= 3) {
 			return false;
 		}
@@ -171,5 +203,125 @@ public class RoomService {
 		}
 
 		member.exitNightRoom();
+	}
+
+	private String getRoomManagerNickname(Long roomId) {
+		return memberService.getManager(roomId).getNickname();
+	}
+
+	private List<RoutineResponse> getRoutineResponses(Long roomId) {
+		List<Routine> roomRoutines = routineSearchRepository.findByRoomId(roomId);
+
+		return roomRoutines.stream().map(RoutineMapper::toRoutineResponse).toList();
+	}
+
+	private List<TodayCertificateRankResponse> getTodayCertificateRankResponses(Long roomId,
+		List<RoutineResponse> routines, List<DailyMemberCertification> dailyMemberCertifications, LocalDate today) {
+
+		List<TodayCertificateRankResponse> responses = new ArrayList<>();
+		List<Long> routineIds = routines.stream()
+			.map(RoutineResponse::routineId)
+			.toList();
+		List<Certification> certifications = certificationsSearchRepository.findCertifications(
+			routineIds,
+			today);
+		List<Participant> participants = participantSearchRepository.findParticipants(roomId);
+		List<Member> members = memberService.getRoomMembers(participants.stream()
+			.map(Participant::getMemberId)
+			.toList());
+
+		addCompletedMembers(responses, dailyMemberCertifications, members, certifications, participants, today);
+		addUncompletedMembers(responses, dailyMemberCertifications, members, participants, today);
+
+		return responses;
+	}
+
+	private List<DailyMemberCertification> getDailyMemberCertificationSorted(Long roomId, LocalDate date) {
+		List<DailyMemberCertification> dailyMemberCertifications =
+			certificationsSearchRepository.findDailyMemberCertifications(roomId, date);
+
+		return dailyMemberCertifications.stream()
+			.sorted(Comparator.comparing(
+				dailyMemberCertification -> dailyMemberCertification.getParticipant().getCreatedAt())
+			)
+			.toList();
+	}
+
+	private void addCompletedMembers(List<TodayCertificateRankResponse> responses,
+		List<DailyMemberCertification> dailyMemberCertifications, List<Member> members,
+		List<Certification> certifications, List<Participant> participants, LocalDate today) {
+
+		int rank = 1;
+
+		for (DailyMemberCertification certification : dailyMemberCertifications) {
+			Member member = members.stream()
+				.filter(m -> m.getId().equals(certification.getMemberId()))
+				.findAny()
+				.orElseThrow(() -> new NotFoundException(ROOM_DETAILS_ERROR));
+
+			int contributionPoint = calculateContributionPoint(member.getId(), participants, today);
+			List<CertificationImageResponse> cftImageResponses = CertificationsMapper.toCftImageResponses(
+				member.getId(),
+				certifications);
+
+			TodayCertificateRankResponse response = CertificationsMapper.toTodayCftRankResponse(
+				rank, member, contributionPoint, "https://~awake", "https://~sleep", cftImageResponses);
+
+			rank += 1;
+			responses.add(response);
+		}
+	}
+
+	private void addUncompletedMembers(List<TodayCertificateRankResponse> responses,
+		List<DailyMemberCertification> dailyMemberCertifications, List<Member> members,
+		List<Participant> participants, LocalDate today) {
+
+		List<Long> allMemberIds = participants.stream()
+			.map(Participant::getMemberId)
+			.collect(Collectors.toList());
+
+		List<Long> certifiedMemberIds = dailyMemberCertifications.stream()
+			.map(DailyMemberCertification::getMemberId)
+			.toList();
+
+		allMemberIds.removeAll(certifiedMemberIds);
+
+		for (Long memberId : allMemberIds) {
+			Member member = members.stream()
+				.filter(m -> m.getId().equals(memberId))
+				.findAny()
+				.orElseThrow(() -> new NotFoundException(ROOM_DETAILS_ERROR));
+
+			int contributionPoint = calculateContributionPoint(memberId, participants, today);
+
+			TodayCertificateRankResponse response = CertificationsMapper.toTodayCftRankResponse(
+				500, member, contributionPoint, "https://~awake", "https://~sleep", null);
+
+			responses.add(response);
+		}
+	}
+
+	private int calculateContributionPoint(Long memberId, List<Participant> participants, LocalDate today) {
+		Participant participant = participants.stream()
+			.filter(p -> p.getMemberId().equals(memberId))
+			.findAny()
+			.orElseThrow(() -> new NotFoundException(ROOM_DETAILS_ERROR));
+
+		int participatedDays = Period.between(participant.getCreatedAt().toLocalDate(), today).getDays() + 1;
+
+		return (int)(((double)participant.getCertifyCount() / participatedDays) * 100);
+	}
+
+	private List<LocalDate> getCertifiedDates(Long roomId, LocalDate today) {
+		List<DailyRoomCertification> certifications = certificationsSearchRepository.findDailyRoomCertifications(
+			roomId, today);
+
+		return certifications.stream().map(DailyRoomCertification::getCertifiedAt).toList();
+	}
+
+	private double calculateCompletePercentage(int certifiedMembersCount, int currentsMembersCount) {
+		double completePercentage = ((double)certifiedMembersCount / currentsMembersCount) * 100;
+
+		return Math.round(completePercentage * 100) / 100.0;
 	}
 }

--- a/src/main/java/com/moabam/api/domain/entity/DailyMemberCertification.java
+++ b/src/main/java/com/moabam/api/domain/entity/DailyMemberCertification.java
@@ -1,14 +1,20 @@
 package com.moabam.api.domain.entity;
 
+import static java.util.Objects.*;
+
 import com.moabam.global.common.entity.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +34,16 @@ public class DailyMemberCertification extends BaseTimeEntity {
 
 	@Column(name = "room_id", nullable = false, updatable = false)
 	private Long roomId;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "participant_id") // Participant createdAt으로 방 참여 시작 날짜 확인, certifyCount 가져다가 쓰기
+	private Participant participant;
+
+	@Builder
+	private DailyMemberCertification(Long id, Long memberId, Long roomId, Participant participant) {
+		this.id = id;
+		this.memberId = requireNonNull(memberId);
+		this.roomId = requireNonNull(roomId);
+		this.participant = requireNonNull(participant);
+	}
 }

--- a/src/main/java/com/moabam/api/domain/entity/DailyMemberCertification.java
+++ b/src/main/java/com/moabam/api/domain/entity/DailyMemberCertification.java
@@ -1,0 +1,31 @@
+package com.moabam.api.domain.entity;
+
+import com.moabam.global.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "daily_member_certification") // 매일 사용자가 방에 인증을 완료했는지 -> createdAt으로 인증 시각 확인
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyMemberCertification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "member_id", nullable = false, updatable = false)
+	private Long memberId;
+
+	@Column(name = "room_id", nullable = false, updatable = false)
+	private Long roomId;
+}

--- a/src/main/java/com/moabam/api/domain/entity/DailyRoomCertification.java
+++ b/src/main/java/com/moabam/api/domain/entity/DailyRoomCertification.java
@@ -1,5 +1,7 @@
 package com.moabam.api.domain.entity;
 
+import static java.util.Objects.*;
+
 import java.time.LocalDate;
 
 import jakarta.persistence.Column;
@@ -9,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -28,4 +31,11 @@ public class DailyRoomCertification {
 
 	@Column(name = "certified_at", nullable = false, updatable = false)
 	private LocalDate certifiedAt;
+
+	@Builder
+	private DailyRoomCertification(Long id, Long roomId, LocalDate certifiedAt) {
+		this.id = id;
+		this.roomId = requireNonNull(roomId);
+		this.certifiedAt = requireNonNull(certifiedAt);
+	}
 }

--- a/src/main/java/com/moabam/api/domain/entity/DailyRoomCertification.java
+++ b/src/main/java/com/moabam/api/domain/entity/DailyRoomCertification.java
@@ -1,0 +1,31 @@
+package com.moabam.api.domain.entity;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "daily_room_certification") // 매일 방이 인증을 완료했는지 -> certifiedAt으로 인증 날짜 확인
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DailyRoomCertification {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "room_id", nullable = false, updatable = false)
+	private Long roomId;
+
+	@Column(name = "certified_at", nullable = false, updatable = false)
+	private LocalDate certifiedAt;
+}

--- a/src/main/java/com/moabam/api/domain/entity/Participant.java
+++ b/src/main/java/com/moabam/api/domain/entity/Participant.java
@@ -33,7 +33,7 @@ public class Participant {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "room_id", updatable = false)
+	@JoinColumn(name = "room_id")
 	private Room room;
 
 	@Column(name = "member_id", updatable = false, nullable = false)

--- a/src/main/java/com/moabam/api/domain/entity/Participant.java
+++ b/src/main/java/com/moabam/api/domain/entity/Participant.java
@@ -6,6 +6,8 @@ import java.time.LocalDateTime;
 
 import org.hibernate.annotations.SQLDelete;
 
+import com.moabam.global.common.entity.BaseTimeEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +27,7 @@ import lombok.NoArgsConstructor;
 @Table(name = "participant")
 @SQLDelete(sql = "UPDATE participant SET deleted_at = CURRENT_TIMESTAMP where id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Participant {
+public class Participant extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/moabam/api/domain/entity/Routine.java
+++ b/src/main/java/com/moabam/api/domain/entity/Routine.java
@@ -30,7 +30,7 @@ public class Routine extends BaseTimeEntity {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "room_id", nullable = false, updatable = false)
+	@JoinColumn(name = "room_id", updatable = false)
 	private Room room;
 
 	@Column(name = "content", nullable = false, length = 60)

--- a/src/main/java/com/moabam/api/domain/repository/CertificationsMapper.java
+++ b/src/main/java/com/moabam/api/domain/repository/CertificationsMapper.java
@@ -1,0 +1,49 @@
+package com.moabam.api.domain.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.moabam.api.domain.entity.Certification;
+import com.moabam.api.domain.entity.Member;
+import com.moabam.api.dto.CertificationImageResponse;
+import com.moabam.api.dto.TodayCertificateRankResponse;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CertificationsMapper {
+
+	public static List<CertificationImageResponse> toCftImageResponses(Long memberId,
+		List<Certification> certifications) {
+		List<CertificationImageResponse> cftImageResponses = new ArrayList<>();
+		List<Certification> filteredCertifications = certifications.stream()
+			.filter(certification -> certification.getMemberId().equals(memberId))
+			.toList();
+
+		for (Certification certification : filteredCertifications) {
+			CertificationImageResponse cftImageResponse = CertificationImageResponse.builder()
+				.routineId(certification.getRoutine().getId())
+				.image(certification.getImage())
+				.build();
+
+			cftImageResponses.add(cftImageResponse);
+		}
+
+		return cftImageResponses;
+	}
+
+	public static TodayCertificateRankResponse toTodayCftRankResponse(int rank, Member member, int contributionPoint,
+		String awakeImage, String sleepImage, List<CertificationImageResponse> cftImageResponses) {
+		return TodayCertificateRankResponse.builder()
+			.rank(rank)
+			.memberId(member.getId())
+			.nickname(member.getNickname())
+			.profileImage(member.getProfileImage())
+			.contributionPoint(contributionPoint)
+			.awakeImage(awakeImage)
+			.sleepImage(sleepImage)
+			.certificationImage(cftImageResponses)
+			.build();
+	}
+}

--- a/src/main/java/com/moabam/api/domain/repository/CertificationsSearchRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/CertificationsSearchRepository.java
@@ -1,0 +1,65 @@
+package com.moabam.api.domain.repository;
+
+import static com.moabam.api.domain.entity.QCertification.*;
+import static com.moabam.api.domain.entity.QDailyMemberCertification.*;
+import static com.moabam.api.domain.entity.QDailyRoomCertification.*;
+import static com.moabam.api.domain.entity.QParticipant.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.moabam.api.domain.entity.Certification;
+import com.moabam.api.domain.entity.DailyMemberCertification;
+import com.moabam.api.domain.entity.DailyRoomCertification;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CertificationsSearchRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<Certification> findCertifications(List<Long> routineIds, LocalDate date) {
+		BooleanExpression expression = null;
+
+		for (Long routineId : routineIds) {
+			BooleanExpression routineExpression = certification.routine.id.eq(routineId);
+			expression = expression == null ? routineExpression : expression.or(routineExpression);
+		}
+
+		return jpaQueryFactory
+			.selectFrom(certification)
+			.where(
+				expression,
+				certification.createdAt.between(date.atStartOfDay(), date.atTime(LocalTime.MAX))
+			)
+			.fetch();
+	}
+
+	public List<DailyMemberCertification> findDailyMemberCertifications(Long roomId, LocalDate date) {
+		return jpaQueryFactory
+			.selectFrom(dailyMemberCertification)
+			.join(dailyMemberCertification.participant, participant).fetchJoin()
+			.where(
+				dailyMemberCertification.roomId.eq(roomId),
+				dailyMemberCertification.createdAt.between(date.atStartOfDay(), date.atTime(LocalTime.MAX))
+			)
+			.fetch();
+	}
+
+	public List<DailyRoomCertification> findDailyRoomCertifications(Long roomId, LocalDate date) {
+		return jpaQueryFactory
+			.selectFrom(dailyRoomCertification)
+			.where(
+				dailyRoomCertification.roomId.eq(roomId),
+				dailyRoomCertification.certifiedAt.eq(date)
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/com/moabam/api/domain/repository/DailyMemberCertificationRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/DailyMemberCertificationRepository.java
@@ -1,0 +1,9 @@
+package com.moabam.api.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.moabam.api.domain.entity.DailyMemberCertification;
+
+public interface DailyMemberCertificationRepository extends JpaRepository<DailyMemberCertification, Long> {
+
+}

--- a/src/main/java/com/moabam/api/domain/repository/DailyRoomCertificationRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/DailyRoomCertificationRepository.java
@@ -1,0 +1,9 @@
+package com.moabam.api.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.moabam.api.domain.entity.DailyRoomCertification;
+
+public interface DailyRoomCertificationRepository extends JpaRepository<DailyRoomCertification, Long> {
+
+}

--- a/src/main/java/com/moabam/api/domain/repository/MemberSearchRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/MemberSearchRepository.java
@@ -1,0 +1,42 @@
+package com.moabam.api.domain.repository;
+
+import static com.moabam.api.domain.entity.QMember.*;
+import static com.moabam.api.domain.entity.QParticipant.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.moabam.api.domain.entity.Member;
+import com.moabam.global.common.util.DynamicQuery;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberSearchRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public Optional<Member> findManager(Long roomId) {
+		return Optional.ofNullable(
+			jpaQueryFactory
+				.selectFrom(member)
+				.where(
+					member.id.eq(
+						JPAExpressions
+							.select(participant.memberId)
+							.from(participant)
+							.where(
+								DynamicQuery.generateEq(true, participant.isManager::eq),
+								DynamicQuery.generateEq(member.id, participant.memberId::eq),
+								DynamicQuery.generateEq(roomId, participant.room.id::eq)
+							)
+					)
+				)
+				.fetchOne()
+		);
+	}
+}

--- a/src/main/java/com/moabam/api/domain/repository/ParticipantSearchRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/ParticipantSearchRepository.java
@@ -1,7 +1,9 @@
 package com.moabam.api.domain.repository;
 
 import static com.moabam.api.domain.entity.QParticipant.*;
+import static com.moabam.api.domain.entity.QRoom.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
@@ -18,13 +20,25 @@ public class ParticipantSearchRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
 
-	public Optional<Participant> findParticipant(Long memberId, Long roomId) {
+	public Optional<Participant> findByMemberIdAndRoomId(Long memberId, Long roomId) {
 		return Optional.ofNullable(
-			jpaQueryFactory.selectFrom(participant)
+			jpaQueryFactory
+				.selectFrom(participant)
+				.join(participant.room, room).fetchJoin()
 				.where(
 					DynamicQuery.generateEq(roomId, participant.room.id::eq),
 					DynamicQuery.generateEq(memberId, participant.memberId::eq)
-				).fetchOne()
+				)
+				.fetchOne()
 		);
+	}
+
+	public List<Participant> findParticipants(Long roomId) {
+		return jpaQueryFactory
+			.selectFrom(participant)
+			.where(
+				participant.room.id.eq(roomId)
+			)
+			.fetch();
 	}
 }

--- a/src/main/java/com/moabam/api/domain/repository/RoutineSearchRepository.java
+++ b/src/main/java/com/moabam/api/domain/repository/RoutineSearchRepository.java
@@ -1,0 +1,28 @@
+package com.moabam.api.domain.repository;
+
+import static com.moabam.api.domain.entity.QRoutine.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.moabam.api.domain.entity.Routine;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RoutineSearchRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	public List<Routine> findByRoomId(Long roomId) {
+		return jpaQueryFactory
+			.selectFrom(routine)
+			.where(
+				routine.room.id.eq(roomId)
+			)
+			.fetch();
+	}
+}

--- a/src/main/java/com/moabam/api/dto/BugMapper.java
+++ b/src/main/java/com/moabam/api/dto/BugMapper.java
@@ -5,7 +5,7 @@ import com.moabam.api.domain.entity.Bug;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BugMapper {
 
 	public static BugResponse toBugResponse(Bug bug) {

--- a/src/main/java/com/moabam/api/dto/CertificationImageResponse.java
+++ b/src/main/java/com/moabam/api/dto/CertificationImageResponse.java
@@ -1,0 +1,11 @@
+package com.moabam.api.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CertificationImageResponse(
+	Long routineId,
+	String image
+) {
+
+}

--- a/src/main/java/com/moabam/api/dto/NotificationMapper.java
+++ b/src/main/java/com/moabam/api/dto/NotificationMapper.java
@@ -7,7 +7,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class NotificationMapper {
+public final class NotificationMapper {
 
 	private static final String TITLE = "모아밤";
 	private static final String KNOCK_BODY = "님이 콕 찔렀습니다.";

--- a/src/main/java/com/moabam/api/dto/OAuthMapper.java
+++ b/src/main/java/com/moabam/api/dto/OAuthMapper.java
@@ -6,7 +6,7 @@ import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class OAuthMapper {
+public final class OAuthMapper {
 
 	public static AuthorizationCodeRequest toAuthorizationCodeRequest(OAuthConfig oAuthConfig) {
 		return AuthorizationCodeRequest.builder()

--- a/src/main/java/com/moabam/api/dto/ProductMapper.java
+++ b/src/main/java/com/moabam/api/dto/ProductMapper.java
@@ -7,7 +7,7 @@ import com.moabam.api.domain.entity.Product;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ProductMapper {
 
 	public static ProductResponse toProductResponse(Product product) {

--- a/src/main/java/com/moabam/api/dto/RoomDetailsResponse.java
+++ b/src/main/java/com/moabam/api/dto/RoomDetailsResponse.java
@@ -1,0 +1,26 @@
+package com.moabam.api.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record RoomDetailsResponse(
+	Long roomId,
+	String title,
+	String managerNickName,
+	String roomImage,
+	int level,
+	String roomType,
+	int certifyTime,
+	int currentUserCount,
+	int maxUserCount,
+	String announcement,
+	double completePercentage,
+	List<LocalDate> certifiedDates,
+	List<RoutineResponse> routine,
+	List<TodayCertificateRankResponse> todayCertificateRank
+) {
+
+}

--- a/src/main/java/com/moabam/api/dto/RoomMapper.java
+++ b/src/main/java/com/moabam/api/dto/RoomMapper.java
@@ -1,5 +1,8 @@
 package com.moabam.api.dto;
 
+import java.time.LocalDate;
+import java.util.List;
+
 import com.moabam.api.domain.entity.Room;
 
 import lombok.AccessLevel;
@@ -15,6 +18,27 @@ public final class RoomMapper {
 			.roomType(createRoomRequest.roomType())
 			.certifyTime(createRoomRequest.certifyTime())
 			.maxUserCount(createRoomRequest.maxUserCount())
+			.build();
+	}
+
+	public static RoomDetailsResponse toRoomDetailsResponse(Room room, String managerNickname,
+		List<RoutineResponse> routineResponses, List<LocalDate> certifiedDates,
+		List<TodayCertificateRankResponse> todayCertificateRankResponses, double completePercentage) {
+		return RoomDetailsResponse.builder()
+			.roomId(room.getId())
+			.title(room.getTitle())
+			.managerNickName(managerNickname)
+			.roomImage(room.getRoomImage())
+			.level(room.getLevel())
+			.roomType(room.getRoomType().name())
+			.certifyTime(room.getCertifyTime())
+			.currentUserCount(room.getCurrentUserCount())
+			.maxUserCount(room.getMaxUserCount())
+			.announcement(room.getAnnouncement())
+			.completePercentage(completePercentage)
+			.certifiedDates(certifiedDates)
+			.routine(routineResponses)
+			.todayCertificateRank(todayCertificateRankResponses)
 			.build();
 	}
 }

--- a/src/main/java/com/moabam/api/dto/RoomMapper.java
+++ b/src/main/java/com/moabam/api/dto/RoomMapper.java
@@ -1,15 +1,12 @@
 package com.moabam.api.dto;
 
-import java.util.List;
-
 import com.moabam.api.domain.entity.Room;
-import com.moabam.api.domain.entity.Routine;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public abstract class RoomMapper {
+public final class RoomMapper {
 
 	public static Room toRoomEntity(CreateRoomRequest createRoomRequest) {
 		return Room.builder()
@@ -19,14 +16,5 @@ public abstract class RoomMapper {
 			.certifyTime(createRoomRequest.certifyTime())
 			.maxUserCount(createRoomRequest.maxUserCount())
 			.build();
-	}
-
-	public static List<Routine> toRoutineEntity(Room room, List<String> routinesRequest) {
-		return routinesRequest.stream()
-			.map(routine -> Routine.builder()
-				.room(room)
-				.content(routine)
-				.build())
-			.toList();
 	}
 }

--- a/src/main/java/com/moabam/api/dto/RoutineMapper.java
+++ b/src/main/java/com/moabam/api/dto/RoutineMapper.java
@@ -19,4 +19,11 @@ public final class RoutineMapper {
 				.build())
 			.toList();
 	}
+
+	public static RoutineResponse toRoutineResponse(Routine routine) {
+		return RoutineResponse.builder()
+			.routineId(routine.getId())
+			.content(routine.getContent())
+			.build();
+	}
 }

--- a/src/main/java/com/moabam/api/dto/RoutineMapper.java
+++ b/src/main/java/com/moabam/api/dto/RoutineMapper.java
@@ -19,11 +19,4 @@ public final class RoutineMapper {
 				.build())
 			.toList();
 	}
-
-	public static RoutineResponse toRoutineResponse(Routine routine) {
-		return RoutineResponse.builder()
-			.routineId(routine.getId())
-			.content(routine.getContent())
-			.build();
-	}
 }

--- a/src/main/java/com/moabam/api/dto/RoutineMapper.java
+++ b/src/main/java/com/moabam/api/dto/RoutineMapper.java
@@ -1,0 +1,29 @@
+package com.moabam.api.dto;
+
+import java.util.List;
+
+import com.moabam.api.domain.entity.Room;
+import com.moabam.api.domain.entity.Routine;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class RoutineMapper {
+
+	public static List<Routine> toRoutineEntities(Room room, List<String> routinesRequest) {
+		return routinesRequest.stream()
+			.map(routine -> Routine.builder()
+				.room(room)
+				.content(routine)
+				.build())
+			.toList();
+	}
+
+	public static RoutineResponse toRoutineResponse(Routine routine) {
+		return RoutineResponse.builder()
+			.routineId(routine.getId())
+			.content(routine.getContent())
+			.build();
+	}
+}

--- a/src/main/java/com/moabam/api/dto/RoutineResponse.java
+++ b/src/main/java/com/moabam/api/dto/RoutineResponse.java
@@ -1,0 +1,11 @@
+package com.moabam.api.dto;
+
+import lombok.Builder;
+
+@Builder
+public record RoutineResponse(
+	Long routineId,
+	String content
+) {
+
+}

--- a/src/main/java/com/moabam/api/dto/TodayCertificateRankResponse.java
+++ b/src/main/java/com/moabam/api/dto/TodayCertificateRankResponse.java
@@ -1,0 +1,19 @@
+package com.moabam.api.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record TodayCertificateRankResponse(
+	int rank,
+	Long memberId,
+	String nickname,
+	String profileImage,
+	int contributionPoint,
+	String awakeImage,
+	String sleepImage,
+	List<CertificationImageResponse> certificationImage
+) {
+
+}

--- a/src/main/java/com/moabam/api/presentation/RoomController.java
+++ b/src/main/java/com/moabam/api/presentation/RoomController.java
@@ -2,6 +2,7 @@ package com.moabam.api.presentation;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -14,6 +15,7 @@ import com.moabam.api.application.RoomService;
 import com.moabam.api.dto.CreateRoomRequest;
 import com.moabam.api.dto.EnterRoomRequest;
 import com.moabam.api.dto.ModifyRoomRequest;
+import com.moabam.api.dto.RoomDetailsResponse;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -48,5 +50,11 @@ public class RoomController {
 	@ResponseStatus(HttpStatus.OK)
 	public void exitRoom(@PathVariable("roomId") Long roomId) {
 		roomService.exitRoom(1L, roomId);
+	}
+
+	@GetMapping("/{roomId}")
+	@ResponseStatus(HttpStatus.OK)
+	public RoomDetailsResponse getRoomDetails(@PathVariable("roomId") Long roomId) {
+		return roomService.getRoomDetails(1L, roomId);
 	}
 }

--- a/src/main/java/com/moabam/global/error/model/ErrorMessage.java
+++ b/src/main/java/com/moabam/global/error/model/ErrorMessage.java
@@ -16,6 +16,7 @@ public enum ErrorMessage {
 	PARTICIPANT_NOT_FOUND("방에 대한 참여자의 정보가 없습니다."),
 	WRONG_ROOM_PASSWORD("방의 비밀번호가 일치하지 않습니다."),
 	ROOM_MAX_USER_REACHED("방의 인원수가 찼습니다."),
+	ROOM_DETAILS_ERROR("방 정보를 불러오는데 실패했습니다."),
 
 	LOGIN_FAILED("로그인에 실패했습니다."),
 	REQUEST_FAILED("네트워크 접근 실패입니다."),

--- a/src/test/java/com/moabam/api/presentation/RoomControllerTest.java
+++ b/src/test/java/com/moabam/api/presentation/RoomControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,9 +25,16 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moabam.api.domain.entity.Certification;
+import com.moabam.api.domain.entity.DailyMemberCertification;
+import com.moabam.api.domain.entity.DailyRoomCertification;
 import com.moabam.api.domain.entity.Member;
 import com.moabam.api.domain.entity.Participant;
 import com.moabam.api.domain.entity.Room;
+import com.moabam.api.domain.entity.Routine;
+import com.moabam.api.domain.repository.CertificationRepository;
+import com.moabam.api.domain.repository.DailyMemberCertificationRepository;
+import com.moabam.api.domain.repository.DailyRoomCertificationRepository;
 import com.moabam.api.domain.repository.MemberRepository;
 import com.moabam.api.domain.repository.ParticipantRepository;
 import com.moabam.api.domain.repository.RoomRepository;
@@ -60,6 +68,15 @@ class RoomControllerTest {
 
 	@Autowired
 	private MemberRepository memberRepository;
+
+	@Autowired
+	private CertificationRepository certificationRepository;
+
+	@Autowired
+	private DailyMemberCertificationRepository dailyMemberCertificationRepository;
+
+	@Autowired
+	private DailyRoomCertificationRepository dailyRoomCertificationRepository;
 
 	Member member;
 
@@ -719,5 +736,106 @@ class RoomControllerTest {
 
 		// then
 		assertThat(getMember.getCurrentNightCount()).isEqualTo(2);
+	}
+
+	@DisplayName("방 상세 정보 조회 성공 테스트")
+	@Test
+	void get_room_details_test() throws Exception {
+		// given
+		Room room = Room.builder()
+			.title("방 제목")
+			.password("1234")
+			.roomType(NIGHT)
+			.certifyTime(23)
+			.maxUserCount(5)
+			.build();
+
+		room.increaseCurrentUserCount();
+		room.increaseCurrentUserCount();
+
+		Routine routine1 = Routine.builder()
+			.room(room)
+			.content("물 마시기")
+			.build();
+
+		Routine routine2 = Routine.builder()
+			.room(room)
+			.content("코테 풀기")
+			.build();
+
+		Participant participant1 = Participant.builder()
+			.room(room)
+			.memberId(1L)
+			.build();
+		participant1.enableManager();
+
+		Member member2 = Member.builder()
+			.socialId("SOCIAL_2")
+			.nickname("NICKNAME_2")
+			.profileImage("PROFILE_IMAGE_2")
+			.bug(BugFixture.bug())
+			.build();
+
+		Member member3 = Member.builder()
+			.socialId("SOCIAL_3")
+			.nickname("NICKNAME_3")
+			.profileImage("PROFILE_IMAGE_3")
+			.bug(BugFixture.bug())
+			.build();
+
+		roomRepository.save(room);
+		routineRepository.save(routine1);
+		routineRepository.save(routine2);
+		memberRepository.save(member2);
+		memberRepository.save(member3);
+
+		Participant participant2 = Participant.builder()
+			.room(room)
+			.memberId(member2.getId())
+			.build();
+
+		Participant participant3 = Participant.builder()
+			.room(room)
+			.memberId(member3.getId())
+			.build();
+
+		participantRepository.save(participant1);
+		participantRepository.save(participant2);
+		participantRepository.save(participant3);
+
+		Certification certification1 = Certification.builder()
+			.routine(routine1)
+			.memberId(member.getId())
+			.image("member1Image")
+			.build();
+
+		Certification certification2 = Certification.builder()
+			.routine(routine2)
+			.memberId(member.getId())
+			.image("member2Image")
+			.build();
+
+		certificationRepository.save(certification1);
+		certificationRepository.save(certification2);
+
+		DailyMemberCertification dailyMemberCertification = DailyMemberCertification.builder()
+			.memberId(member.getId())
+			.roomId(room.getId())
+			.participant(participant1)
+			.build();
+
+		dailyMemberCertificationRepository.save(dailyMemberCertification);
+
+		DailyRoomCertification dailyRoomCertification = DailyRoomCertification.builder()
+			.roomId(room.getId())
+			.certifiedAt(LocalDate.now())
+			.build();
+
+		dailyRoomCertificationRepository.save(dailyRoomCertification);
+
+		// expected
+		mockMvc.perform(get("/rooms/" + room.getId()))
+			.andExpect(status().isOk())
+			.andDo(print());
 	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-
+        highlight_sql: true
   # Redis
   data:
     redis:


### PR DESCRIPTION
## 📋 Checklist

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? (e.g. `feat: 유저 조회 기능 구현`)
- [x] 🏷️ 라벨, 프로젝트, 마일스톤은 등록했나요?
- [x] 🧹 코드 스멜은 해결했나요?

## 🧩 이슈 번호 <!-- 이슈 번호를 작성해주세요 ex) #11 -->

- close #17 

## 👩‍💻 공유 포인트 및 논의 사항

- 이번 기능은 구현 로직이 많이 복잡해서 같이 리뷰를 원하시면 말해주세요!
- 가독성을 위해 여러 개행처리를 했습니다.
- 해당 기능을 구현하다 보니 Entity를 두개를 새로 만들어야 했습니다.
- DailyMemberCertification: 한 유저가 속하는 특정 방에서 인증을 완료하면 만들어지는 Entity입니다. 이때 Entity의 createdAt으로 인증 시각을 확인해서 각 멤버의 인증 완료 순서를 정하고 Participant의 createdAt으로 방 참여 시작 날짜를 확인할 수 있고, certifyCount를 사용하여 기여도를 계산합니다.
- DailyRoomCertification: 방 마다 하루 인증하면 생기는 엔티티입니다. createdAt으로 날짜를 확인 할 수 있으며 이로써 기록을 가져올 수도 있습니다.
- Querydsl을 이용하여 동적쿼리를 만들었고, fetchJoin을 적용하여 중복 쿼리, N+1 문제를 해결했습니다.